### PR TITLE
Fixing URL of management center

### DIFF
--- a/hazelcast-integration/docker-compose/src/main/docker/hazelcast.yml
+++ b/hazelcast-integration/docker-compose/src/main/docker/hazelcast.yml
@@ -16,7 +16,7 @@ services:
     volumes:
         - ../resources:/configFolder
     environment:
-        - JAVA_OPTS=-Dhazelcast.config=/configFolder/hazelcast.xml -Dhazelcast.mancenter.url=http://mancenter:8080/mancenter -Dgroup.name=hz-compose -Dgroup.password=s3crEt
+        - JAVA_OPTS=-Dhazelcast.config=/configFolder/hazelcast.xml -Dhazelcast.mancenter.url=http://mancenter:8080/hazelcast-mancenter -Dgroup.name=hz-compose -Dgroup.password=s3crEt
 #        ports:
 #            - 5701:5701
     links:


### PR DESCRIPTION
The URL was `http://mancenter:8080/mancenter` instead of `http://mancenter:8080/hazelcast-mancenter`